### PR TITLE
Add missing keywords from TypeScript 1.5 and 1.4

### DIFF
--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -276,12 +276,12 @@ Match group 1 is the name of the macro.")
 
 (defconst typescript--keyword-re
   (typescript--regexp-opt-symbol
-   '("any" "bool" "boolean" "break" "case" "catch" "class" "constructor"
-     "continue" "declare" "default" "delete" "do" "else"
+   '("any" "bool" "boolean" "break" "case" "catch" "class" "const"
+     "constructor" "continue" "declare" "default" "delete" "do" "else"
      "enum" "export" "extends" "extern" "false" "finally" "for"
-     "function" "goto" "if" "implements" "import" "in"
-     "instanceof" "interface" "module" "new" "null" "number"
-      "private" "protected" "public" "return" "static" "string"
+     "function" "goto" "if" "implements" "import" "in" "instanceof"
+     "interface" "let" "module" "namespace" "new" "null" "number"
+     "private" "protected" "public" "return" "static" "string"
      "super" "switch"  "this" "throw" "true"
      "try" "typeof" "var" "void"
      "while" ))

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -283,7 +283,7 @@ Match group 1 is the name of the macro.")
      "interface" "let" "module" "namespace" "new" "null" "number"
      "private" "protected" "public" "return" "static" "string"
      "super" "switch"  "this" "throw" "true"
-     "try" "typeof" "var" "void"
+     "try" "type" "typeof" "var" "void"
      "while" ))
   "Regexp matching any typescript keyword.")
 


### PR DESCRIPTION
This adds the keywords `let`, `const` and `type` keyword from TypeScript 1.4 and the `namespace` keyword from TypeScript 1.5