### PR TITLE
Added basic syntax highlighting for arrow functions

### DIFF
--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -1543,8 +1543,12 @@ point of view of font-lock.  It applies highlighting directly with
 
     ;; arrow function formal parameters
     ,(list
-      "(\\(.*\\))\\s-*=>"
+      "(\\([^(]*?\\))\\s-*=>"
       '(1 font-lock-variable-name-face))
+
+    ,(list
+      (concat "\\(" typescript--name-re "\\)\\_>(")
+      '(1 font-lock-function-name-face))
 
     ,(list
       (concat "\\(" typescript--name-re "\\)\\s-*=>")

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -265,6 +265,12 @@ Match group 1 is the name of the function.")
   "Regexp matching a line in the typescript form \"var MUMBLE = function\".
 Match group 1 is MUMBLE.")
 
+(defconst typescript--function-heading-4-re
+  (concat
+   "^\\s-*\\(" typescript--name-re "\\)\\s-*:.*=>")
+  "Regexp matching the start of a function entry in an associative array.
+Match group 1 is the name of the function.")
+
 (defconst typescript--macro-decl-re
   (concat "^\\s-*#\\s-*define\\s-+\\(" typescript--cpp-name-re "\\)\\s-*(")
   "Regexp matching a CPP macro definition, up to the opening parenthesis.
@@ -303,7 +309,8 @@ Match group 1 is the name of the macro.")
   (list
    "\\_<import\\_>"
    (list typescript--function-heading-1-re 1 font-lock-function-name-face)
-   (list typescript--function-heading-2-re 1 font-lock-function-name-face))
+   (list typescript--function-heading-2-re 1 font-lock-function-name-face)
+   (list typescript--function-heading-4-re 1 font-lock-function-name-face))
   "Level one font lock keywords for `typescript-mode'.")
 
 (defconst typescript--font-lock-keywords-2
@@ -1532,7 +1539,16 @@ point of view of font-lock.  It applies highlighting directly with
                  (forward-symbol -1)
                (end-of-line))
             '(end-of-line)
-            '(0 font-lock-variable-name-face))))
+            '(0 font-lock-variable-name-face)))
+
+    ;; arrow function formal parameters
+    ,(list
+      "(\\(.*\\))\\s-*=>"
+      '(1 font-lock-variable-name-face))
+
+    ,(list
+      (concat "\\(" typescript--name-re "\\)\\s-*=>")
+      '(1 font-lock-variable-name-face)))
   "Level three font lock for `typescript-mode'.")
 
 (defun typescript--inside-pitem-p (pitem)


### PR DESCRIPTION
Fast and simple partial sollution for #18 
There is a `"\\_<function\\_>"` pattern for matching functions. I think it should be somehow changed to match arrow functions as well.
