### PR TITLE
Fix wrong cursor position in `typescript-indent-line`

### DIFF
--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -1769,7 +1769,7 @@ nil."
     (widen)
     (let* ((parse-status
             (save-excursion (syntax-ppss (point-at-bol))))
-           (offset (- (current-column) (current-indentation))))
+           (offset (- (point) (line-beginning-position) (current-indentation))))
       (indent-line-to (typescript--proper-indentation parse-status))
       (when (> offset 0) (forward-char offset)))))
 


### PR DESCRIPTION
Cursor jumps to wrong position when editing line includes tab or [fullwidth character](https://en.wikipedia.org/wiki/Halfwidth_and_fullwidth_forms). Because `(current-column)` counts there as 2 or more characters.