### PR TITLE
fix  'function*' indent in class

### DIFF
--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -1643,7 +1643,7 @@ See `font-lock-keywords'.")
   "Regexp matching keywords optionally followed by an opening brace.")
 
 (defconst typescript--indent-operator-re
-  (concat "[-+*/%<>=&^|?:.]\\([^-+*/]\\|$\\)\\|"
+  (concat "[-+/%<>=&^|?:.]\\([^-+/]\\|$\\)\\|"
           (typescript--regexp-opt-symbol '("in" "instanceof")))
   "Regexp matching operators that affect indentation of continued expressions.")
 


### PR DESCRIPTION
it's not good solution  ^_^
```
module.exports =function( app: App)  {
    return class _ extends ctrl_base( app) {
        * index() {
            const client1 = app.mysql.get("db1");
            const results= yield client1.query("show databases");

            return this.output_succ({"sdfall11" : 100});

        }
    }
};



```