### PR TITLE
Fix indentation of methods that are generators.

### DIFF
--- a/test-files/indentation-reference-document.ts
+++ b/test-files/indentation-reference-document.ts
@@ -89,4 +89,77 @@ namespace ts.server {
     process.on("uncaughtException", function (err: Error) {
         ioSession.logError(err, "unknown");
     });
+
+    // Generators as methods.
+    class WithAGeneratorFirst {
+        *blah() {
+        }
+    }
+
+    class WithAGeneratorAfterAProperty {
+        public foo: string = "1";
+
+        *blah() {
+        }
+    }
+
+    class WithAGeneratorAfterAnotherMethod {
+        foo() {
+        }
+
+        *blah() {
+        }
+    }
+
+    class WithSpaceAfterAsterisk  {
+        bar() {
+        }
+
+        * oops() {
+        }
+    }
+
+
+    class WithSpaceAfterParens  {
+        bar() {
+        }
+
+        *oops () {
+        }
+    }
+
+    class WithArguments  {
+        bar() {
+        }
+
+        *oops(foo: number, bar: string) {
+        }
+    }
+
+    // Some continued expressions
+    {
+        const a = 1 *
+            2 /
+            3 +
+            4 -
+            5 %
+            6;
+
+        const b = 1 >
+            2;
+
+        const c = 1 <
+            2;
+
+        const d = 1 &
+            2 |
+            3;
+
+        const e = b ?
+            2 :
+            3;
+
+        const f = window
+            .document;
+    }
 }

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -1655,7 +1655,18 @@ See `font-lock-keywords'.")
          (or (not (looking-at ":"))
              (save-excursion
                (and (typescript--re-search-backward "[?:{]\\|\\_<case\\_>" nil t)
-                    (looking-at "?")))))))
+                    (looking-at "?"))))
+         (not (and
+               (looking-at "*")
+               ;; Generator method (possibly using computed property).
+               (looking-at (concat "\\* *\\(?:\\[\\|" typescript--name-re
+                                   " *(\\)"))
+               (save-excursion
+                 (typescript--backward-syntactic-ws)
+                 ;; We might misindent some expressions that would
+                 ;; return NaN anyway.  Shouldn't be a problem.
+                 (memq (char-before) '(?, ?} ?{ ?\;)))))))
+)
 
 
 (defun typescript--continued-expression-p ()


### PR DESCRIPTION
This is adapted from js.el's js--looking-at-operator-p function.

