### PR TITLE
Don't interpret class members as keywords.

### DIFF
--- a/test-files/indentation-reference-document.ts
+++ b/test-files/indentation-reference-document.ts
@@ -161,5 +161,39 @@ namespace ts.server {
 
         const f = window
             .document;
+
+        const g = f
+            instanceof Object;
+
+        const h = "q"
+            in [1, 2];
+
+    }
+
+    {
+        // Object with fields that are keyword names.
+        const a = {
+            in: 1,
+            IN: 1,
+            instanceof: 1,
+            instanceOf: 1,
+        };
+
+        // Objects with methods that are keyword names.  At the top of
+        // the object declaration, and after a function declaration.
+        class One {
+            instanceOf(): void {
+            }
+
+            in(): void {}
+        }
+
+        // After a field declaration.
+        class Two {
+            foo: boolean = true;
+
+            instanceOf(): void {
+            }
+        }
     }
 }

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -1642,9 +1642,12 @@ See `font-lock-keywords'.")
      "each"))
   "Regexp matching keywords optionally followed by an opening brace.")
 
+(defconst typescript--indent-keyword-re
+  (typescript--regexp-opt-symbol '("in" "instanceof"))
+  "Regexp matching keywords that affect indentation of continued expressions.")
+
 (defconst typescript--indent-operator-re
-  (concat "[-+*/%<>=&^|?:.]\\([^-+*/]\\|$\\)\\|"
-          (typescript--regexp-opt-symbol '("in" "instanceof")))
+  (concat "[-+*/%<>=&^|?:.]\\([^-+*/]\\|$\\)\\|" typescript--indent-keyword-re)
   "Regexp matching operators that affect indentation of continued expressions.")
 
 
@@ -1656,6 +1659,13 @@ See `font-lock-keywords'.")
              (save-excursion
                (and (typescript--re-search-backward "[?:{]\\|\\_<case\\_>" nil t)
                     (looking-at "?"))))
+         ;; Do not identify methods, or fields, that are named "in" or
+         ;; "instanceof" as being operator keywords.
+         (not (and
+               (looking-at typescript--indent-keyword-re)
+               (save-excursion
+                 (typescript--backward-syntactic-ws)
+                 (memq (char-before) '(?, ?{ ?} ?\;)))))
          (not (and
                (looking-at "*")
                ;; Generator method (possibly using computed property).


### PR DESCRIPTION
Without this PR, having a method or field that is named "in" or "instanceof" or the same in a different case (e.g. "instanceOf") results in incorrect indentation.

For the record, I never name my methods "in", but IMO a method named "instanceOf" (with the capitalized "O") should be fair game. Without this PR "instanceOf" is treated as if it were the keyword "instanceof" and indentation is incorrect.