### PR TITLE
Add keyword 'object'

### DIFF
--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -281,7 +281,7 @@ Match group 1 is the name of the macro.")
      "constructor" "continue" "declare" "default" "delete" "do" "else"
      "enum" "export" "extends" "extern" "false" "finally" "for"
      "function" "from" "get" "goto" "if" "implements" "import" "in" "instanceof"
-     "interface" "keyof" "let" "module" "namespace" "new" "null" "number" "of"
+     "interface" "keyof" "let" "module" "namespace" "new" "null" "number" "object" "of"
      "private" "protected" "public" "readonly" "return" "set" "static" "string"
      "super" "switch"  "this" "throw" "true"
      "try" "type" "typeof" "var" "void"


### PR DESCRIPTION
Add support for the 'object' keyword, introduced in TypeScript 2.2 as the recommended type to describe objects.

More information:
https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type

Please let me know if I should do something different.