### PR TITLE
Fix indentation for union type in return annotation

### DIFF
--- a/test-files/indentation-reference-document.ts
+++ b/test-files/indentation-reference-document.ts
@@ -282,6 +282,13 @@ function bif(a: number,
     return "abc):d";
 }
 
+// Generic and union in return type. This case was constructed from
+// a specific bug in the indentation code.
+function bif2(a: number,
+              b: number): Array<number> | number {
+    return 1;
+}
+
 // Comment where the return type would appear.
 function gogo(a: number,
               b: number) /* foo */ {

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -1809,14 +1809,15 @@ moved on success."
             (loop named search-loop
                   do (progn
                        (cond
+                        ;; Looking at the arrow of an arrow function:
+                        ;; move back over the arrow.
+                        ((looking-back "=>" (- (point) 2))
+                         (backward-char 2))
+                        ;; Looking at the end of the parameters list
+                        ;; of a generic: move back over the list.
                         ((eq (char-before) ?>)
-                         (if (looking-back "=>" (- (point) 2))
-                             ;; Move back over the arrow of an arrow function.
-                             (backward-char 2)
-                           ;; Otherwise, we are looking at the end of the parameters
-                           ;; list of a generic. We need to move back over the list.
-                           (backward-char)
-                           (typescript--backward-over-generic-parameter-list)))
+                         (backward-char)
+                         (typescript--backward-over-generic-parameter-list))
                         ;; Looking at a union: skip over the character.
                         ((eq (char-before) ?|)
                          (backward-char))

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -1808,18 +1808,23 @@ moved on success."
           (save-excursion
             (loop named search-loop
                   do (progn
-                       (if (eq (char-before) ?>)
-                           (if (looking-back "=>" (- (point) 2))
-                               ;; Move back over the arrow of an arrow function.
-                               (backward-char 2)
-                             ;; Otherwise, we are looking at the end of the parameters
-                             ;; list of a generic. We need to move back over the list.
-                             (backward-char)
-                             (typescript--backward-over-generic-parameter-list))
-                         ;; General case: we just move back over the current sexp.
+                       (cond
+                        ((eq (char-before) ?>)
+                         (if (looking-back "=>" (- (point) 2))
+                             ;; Move back over the arrow of an arrow function.
+                             (backward-char 2)
+                           ;; Otherwise, we are looking at the end of the parameters
+                           ;; list of a generic. We need to move back over the list.
+                           (backward-char)
+                           (typescript--backward-over-generic-parameter-list)))
+                        ;; Looking at a union: skip over the character.
+                        ((eq (char-before) ?|)
+                         (backward-char))
+                        ;; General case: we just move back over the current sexp.
+                        (t
                          (condition-case nil
                              (backward-sexp)
-                           (scan-error nil)))
+                           (scan-error nil))))
                        (typescript--backward-syntactic-ws)
                        (let ((before (char-before)))
                          ;; Check whether we are at "):".

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -1890,11 +1890,6 @@ moved on success."
                    (when (or (typescript--backward-to-parameter-list)
                              (eq (char-before) ?\)))
                      (backward-list))
-                   ;; If the parameter list is preceded by (, take the
-                   ;; start of the parameter list as our reference.
-                   ;; This allows handling functions in parameter
-                   ;; lists. Otherwise, we want to go back to the
-                   ;; start of function declaration.
                    (back-to-indentation)
                    (cond (same-indent-p
                           (current-column))


### PR DESCRIPTION
This fixes a mistake in the indentation changes I made previously, and cleans up a leftover comment and the code a bit.