### PR TITLE
jsdoc fontification and spellcheck support

### DIFF
--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2265,9 +2265,8 @@ Key bindings:
     ;; Avoid byte-compilation errors.  `font-lock-fontify-buffer' is
     ;; marked as interactive only in Emacs 25.
     (with-no-warnings
-      (font-lock-fontify-buffer)))
+      (font-lock-fontify-buffer))))
 
-  (run-mode-hooks 'typescript-mode-hook))
 
 ;;;###autoload
 (eval-after-load 'folding

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2487,23 +2487,7 @@ Key bindings:
     (c-setup-paragraph-variables))
 
   (set (make-local-variable 'syntax-begin-function)
-       #'typescript--syntax-begin-function)
-
-  ;; Important to fontify the whole buffer syntactically! If we don't,
-  ;; then we might have regular expression literals that aren't marked
-  ;; as strings, which will screw up parse-partial-sexp, scan-lists,
-  ;; etc. and and produce maddening "unbalanced parenthesis" errors.
-  ;; When we attempt to find the error and scroll to the portion of
-  ;; the buffer containing the problem, JIT-lock will apply the
-  ;; correct syntax to the regular expresion literal and the problem
-  ;; will mysteriously disappear.
-  (font-lock-set-defaults)
-
-  (let (font-lock-keywords)         ; leaves syntactic keywords intact
-    ;; Avoid byte-compilation errors.  `font-lock-fontify-buffer' is
-    ;; marked as interactive only in Emacs 25.
-    (with-no-warnings
-      (font-lock-fontify-buffer))))
+       #'typescript--syntax-begin-function))
 
 ;; Set our custom predicate for flyspell prog mode
 (put 'typescript-mode 'flyspell-mode-predicate


### PR DESCRIPTION
This is the fleshed out version of 

https://github.com/ananthakumaran/typescript.el/tree/experiment/typedoc-tags

I've purposely split it into multiple commits:

1. There was an explicit invocation of the mode hooks in the code. I've removed it because `define-derived-mode` should call it automatically. (It sure does call it for me.) So the explicit invocation was redundant.

2. I've added fontification support for the jsdoc/typedoc tags. It is **very** unlikely to be the final word on this. The fact of the matter is that "jsdoc" is really a family of dialects for writing JavaScript documentation. Typedoc is one member of the family which focuses on the needs of TypeScript. Anyway, there's no definite set of tags for "jsdoc". Such and such version of jsdoc3 supports a definite set of tags, but some people use Google's Closure compiler which supports a different dialect, others run jsdoc2 (they really shouldn't but...) which supports another dialect, Typedoc supports yet another dialect, etc. I've named Elisp symbols so that those which deal with features usually common across dialects have `jsdoc` in their name, and those which are specific to Typedoc have `typedoc` in their name.

3. I've added a custom predicate for `flyspell-prog-mode`. In addition to the default fontification-based logic that `flyspell.el` provides, it excludes from spell-checking strings in `import` statements that refer to module names.

4. I've removed the fontification hack reported in #50.

I see there are CI failures on older versions of Emacs. I don't know yet what the solution for that is going to be.

I've used this code to spell check a fairly large code-base that uses Typedoc as its documentation processing tool.