### PR TITLE
Highlight function name for exported or declared functions.

### DIFF
--- a/typescript-mode-tests.el
+++ b/typescript-mode-tests.el
@@ -256,18 +256,32 @@ new line after the start of '/**'."
      ("@param" . typescript-jsdoc-tag)
      ("meow" . typescript-jsdoc-value))))
 
+(defun copy-test-n (n location-root expected)
+  (let (tests)
+    (dotimes (i n tests)
+      (setq tests
+            (cons (cons (concat location-root (number-to-string i)) expected)
+                  tests)))))
+
 (ert-deftest font-lock/function-definition-prefixes ()
   "Tests that function names are highlighted in definitions, even
 when prefixed with module modifiers."
   (font-lock-test
-   "function basicDefn(x: number, y: string): boolean {}\n
-export function exportedDefn(x: number, y: string): boolean {}\n
-export default function exportedDefaultDefn(x: number, y: string): boolean {}\n
-declare function declareFunctionDefn(x: number, y: string): boolean;"
-   '(("basicDefn" . font-lock-function-name-face)
-     ("exportedDefn" . font-lock-function-name-face)
-     ("exportedDefaultDefn" . font-lock-function-name-face)
-     ("declareFunctionDefn" . font-lock-function-name-face))))
+   "function basicDefn(x0: xty0, y0: yty0): ret0 {}\n
+export function exportedDefn(x1: xty1, y1: yty1): ret1 {}\n
+export default function exportedDefaultDefn(x2: xty2, y2: yty2): ret2 {}\n
+declare function declareFunctionDefn(x3: xty3, y3: yty3): ret3;"
+   (append
+    '(("basicDefn" . font-lock-function-name-face)
+      ("exportedDefn" . font-lock-function-name-face)
+      ("exportedDefaultDefn" . font-lock-function-name-face)
+      ("declareFunctionDefn" . font-lock-function-name-face))
+    (copy-test-n 4 "x" font-lock-variable-name-face)
+    (copy-test-n 4 "y" font-lock-variable-name-face)
+    (copy-test-n 4 "xty" font-lock-variable-name-face)
+    (copy-test-n 4 "yty" font-lock-variable-name-face)
+    ;; Return types are not highlighted currently.
+    (copy-test-n 4 "ret" nil))))
 
 (defun flyspell-predicate-test (search-for)
   "This function runs a test on

--- a/typescript-mode-tests.el
+++ b/typescript-mode-tests.el
@@ -256,6 +256,19 @@ new line after the start of '/**'."
      ("@param" . typescript-jsdoc-tag)
      ("meow" . typescript-jsdoc-value))))
 
+(ert-deftest font-lock/function-definition-prefixes ()
+  "Tests that function names are highlighted in definitions, even
+when prefixed with module modifiers."
+  (font-lock-test
+   "function basicDefn(x: number, y: string): boolean {}\n
+export function exportedDefn(x: number, y: string): boolean {}\n
+export default function exportedDefaultDefn(x: number, y: string): boolean {}\n
+declare function declareFunctionDefn(x: number, y: string): boolean;"
+   '(("basicDefn" . font-lock-function-name-face)
+     ("exportedDefn" . font-lock-function-name-face)
+     ("exportedDefaultDefn" . font-lock-function-name-face)
+     ("declareFunctionDefn" . font-lock-function-name-face))))
+
 (defun flyspell-predicate-test (search-for)
   "This function runs a test on
 `typescript--flyspell-mode-predicate'.  `SEARCH-FOR' is a string

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -104,6 +104,10 @@ and group 3 is the 'function' keyword.")
   "Regexp matching a typescript explicit prototype \"class\" declaration.
 An example of this is \"Class.prototype = { method1: ...}\".")
 
+(defconst typescript--module-declaration-re
+  "^\\s-*\\(?:declare\\|\\(?:export\\(?:\\s-+default\\)?\\)\\)?"
+  "Regexp matching ambient declaration modifier or export declaration")
+
 ;; var NewClass = BaseClass.extend(
 (defconst typescript--mp-class-decl-re
   (concat "^\\s-*var\\s-+"
@@ -249,7 +253,8 @@ name as matched contains
 
 (defconst typescript--function-heading-1-re
   (concat
-   "^\\s-*function\\s-+\\(" typescript--name-re "\\)")
+   typescript--module-declaration-re
+   "\\s-*function\\s-+\\(" typescript--name-re "\\)")
   "Regexp matching the start of a typescript function header.
 Match group 1 is the name of the function.")
 


### PR DESCRIPTION
Addresses the following issue (#53):

Extends syntax highlighting for function names to the following cases:

```
export function foo() { }
export default function foo() { }
declare function foo();
```
specifically: when `export`, `export default`, or `declare` precedes a function definition.