### PR TITLE
Fix handling of array shorthand messing up indentation, and simplify typescript--backward-to-parameter-list

### DIFF
--- a/test-files/indentation-reference-document.ts
+++ b/test-files/indentation-reference-document.ts
@@ -299,6 +299,24 @@ function bif2(a: number,
     return 1;
 }
 
+// Array shorthand.
+function bif3(a: number,
+              b: number): number[] {
+    return [1];
+}
+
+// Array shorthand in union.
+function bif4(a: number,
+              b: number): number[] | number {
+    return [1];
+}
+
+// Array shorthand in union, with spaces.
+function bif5(a: number,
+              b: number): number[   ] | number {
+    return [1];
+}
+
 // Comment where the return type would appear.
 function gogo(a: number,
               b: number) /* foo */ {

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2107,6 +2107,8 @@ moved on success."
                               (eq before ?.)
                               ;; Typeguard (eg. foo is SomeClass)
                               (looking-back "is" (- (point) 2))
+                              ;; Array shorthand
+                              (eq before ?\])
                               ;; This is also dealing with dotted names. This may come
                               ;; into play if a jump back moves over an entire dotted
                               ;; name at once.


### PR DESCRIPTION
The first commit fixes indentation when there is an array shorthand (`foo[]` by opposition to `Array<foo>`) in a return value type.

The 2nd commit is a simplification of `typescript--backward-to-parameter-list`. As I was producing the fix in the first commit, I figured that there ought to be a way to simplify the code. If I were just submitting the 1st commit, I'd just push it to `master`, but I want to give interested people an opportunity to comment on the simplification (2nd commit), if desired.

If I don't hear anything 48 hours from this post, I'll merge into `master`.