### PR TITLE
Make the comment-start and comment-end variables local.

### DIFF
--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2453,27 +2453,22 @@ Key bindings:
   :group 'typescript
   :syntax-table typescript-mode-syntax-table
 
-  (set (make-local-variable 'indent-line-function) 'typescript-indent-line)
-  (set (make-local-variable 'beginning-of-defun-function)
-       'typescript-beginning-of-defun)
-  (set (make-local-variable 'end-of-defun-function)
-       'typescript-end-of-defun)
-
-  (set (make-local-variable 'open-paren-in-column-0-is-defun-start) nil)
-  (set (make-local-variable 'font-lock-defaults)
+  (setq-local indent-line-function 'typescript-indent-line)
+  (setq-local beginning-of-defun-function 'typescript-beginning-of-defun)
+  (setq-local end-of-defun-function 'typescript-end-of-defun)
+  (setq-local open-paren-in-column-0-is-defun-start nil)
+  (setq-local font-lock-defaults
        (list typescript--font-lock-keywords
 	     nil nil nil nil
 	     '(font-lock-syntactic-keywords
                . typescript-font-lock-syntactic-keywords)))
-
-  (set (make-local-variable 'parse-sexp-ignore-comments) t)
-  (set (make-local-variable 'parse-sexp-lookup-properties) t)
+  (setq-local parse-sexp-ignore-comments t)
+  (setq-local parse-sexp-lookup-properties t)
 
   ;; Comments
-  (setq comment-start "// ")
-  (setq comment-end "")
-  (set (make-local-variable 'fill-paragraph-function)
-       'typescript-c-fill-paragraph)
+  (setq-local comment-start "// ")
+  (setq-local comment-end "")
+  (setq-local fill-paragraph-function 'typescript-c-fill-paragraph)
 
   ;; Parse cache
   (add-hook 'before-change-functions #'typescript--flush-caches t t)
@@ -2503,8 +2498,7 @@ Key bindings:
     (make-local-variable 'adaptive-fill-regexp)
     (c-setup-paragraph-variables))
 
-  (set (make-local-variable 'syntax-begin-function)
-       #'typescript--syntax-begin-function))
+  (setq-local syntax-begin-function #'typescript--syntax-begin-function))
 
 ;; Set our custom predicate for flyspell prog mode
 (put 'typescript-mode 'flyspell-mode-predicate


### PR DESCRIPTION
Leaving them global as we did was a bug, which did cause me problems. I'd try to use `comment-region` in a TypeScript buffer and get my lines prepended with `# ` instead of `// ` (probably because something else was resetting the global `comment-start` and `comment-end` at some point). That was very annoying. Conversely, I ran into the reverse situation a couple times: commenting in a buffer where `# ` should have been used, resulted in `// ` being used instead. Most of the time I did not want to stop my work to track down the problem --- I just restarted the mode instead --- but I finally took the time and here's the fix.

I've also replaced the verbose code that sets local variables with `setq-local`.

This is not something I'd test for in the test suite but maybe there's an argument to be made for it??