### PR TITLE
Fix regexp fontification.

### DIFF
--- a/typescript-mode-tests.el
+++ b/typescript-mode-tests.el
@@ -197,6 +197,9 @@ LOCATION can be either a single location, or list of locations,
 that are all expected to have the same face."
   (test-with-temp-buffer
    contents
+   ;; Make sure our propertize function has been applied to the whole
+   ;; buffer.
+   (syntax-propertize (point-max))
    (dolist (spec expected)
      (if (listp (car spec))
          (dolist (source (car spec))
@@ -289,6 +292,18 @@ declare function declareFunctionDefn(x3: xty3, y3: yty3): ret3;"
   (font-lock-test "var a = /flip\\/flop/;"
                   '(("=" . nil)
                     (("/flip" "\\\\" "/" "flop/") . font-lock-string-face)
+                    (";" . nil)))
+  ;; Make sure a forward slash in a character class is handled fine.
+  ;; It must not terminate the regular expression.
+  (font-lock-test "var a = /[/]/;"
+                  '(("=" . nil)
+                    (("/" "\\[/" "\\]/") . font-lock-string-face)
+                    (";" . nil)))
+  ;; Make sure an open bracket in a character class does not
+  ;; throw off fontification.
+  (font-lock-test "var a = /[[]/;"
+                  '(("=" . nil)
+                    (("/" "\\[\\[\\]" "/") . font-lock-string-face)
                     (";" . nil)))
   ;; A sequence of two forward slashes is never a regex, so there is
   ;; no such thing as an \"empty regex\" when we use the forward slash

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -1921,8 +1921,6 @@ This performs fontification according to `typescript--class-styles'."
 
 (defun typescript-syntax-propertize (start end)
   ;; JavaScript allows immediate regular expression objects, written /.../.
-  (goto-char start)
-  (typescript-syntax-propertize-regexp end)
   (funcall
    (syntax-propertize-rules
     ;; Distinguish /-division from /-regexp chars (and from /-comment-starter).
@@ -1945,8 +1943,9 @@ This performs fontification according to `typescript--class-styles'."
            (put-text-property (match-beginning 1) (match-end 1)
                               'syntax-table (string-to-syntax "\"/"))
            (typescript-syntax-propertize-regexp end)))))
+    ;; Hash-bang at beginning of buffer.
     ("\\`\\(#\\)!" (1 "< b")))
-   (point) end))
+   start end))
 
 ;;; Indentation
 


### PR DESCRIPTION
Might as well copy here the 2nd commit message...

Use syntax-propertize-function to fontify regexps.  The complexity of regular expressions taxes the basic facilities for funtification. We reuse the latest js.el code that handles fontification to fix lingering issues with how typescript-mode has handled regexp fontification so far.

We do not simply set `syntax-propertize-function` to `js-syntax-propertize` because the latest version of js.el shipped with Emacs has a buggy implementation. Our choices are: copy from the latest version of js.el, come up with some other implementation, or accept to live with buggy fontification.

Closes #44.

I copied the functions from `js.el` wholesale and renamed them. I'm not a fan of copy-rename, but I see this as the least objectionable option from the three I mentioned above. The current bugs with regexp fontification are extremely annoying, and I don't have time to come up with my own implementation. (I'd probably end up with something similar to what `js.el` does, anyway.)

This is a significant change. So there should be discussion before it is merged. I'm not looking for a line-by-line review but there should at least be some sort of consensus.