### PR TITLE
Fix the incorrect indentation of functions that have numbers in their return type annotation.

### DIFF
--- a/test-files/indentation-reference-document.ts
+++ b/test-files/indentation-reference-document.ts
@@ -488,6 +488,19 @@ function foo12(): void {
     });
 }
 
+// Number literals in the return type annotation.
+function foo13(something: string,
+               somethingElse: string): 0b1 | 0 | -1 | 0o2 | 0x3f {
+    return 0;
+}
+
+// No spaces between numbers and type union symbols. (Also changed the
+// notation to uppercase where possible.)
+function foo14(something: string,
+               somethingElse: string): 0B1|0|-1|0O2|0X3F {
+    return 0;
+}
+
 const a =
     1; // Blah
 const b = 2;

--- a/typescript-mode-tests.el
+++ b/typescript-mode-tests.el
@@ -99,6 +99,23 @@ a severity set to WARNING, no rule name."
     (should (string-equal (nth 4 matches) "1"))
     (should (string-equal (nth 5 matches) "83"))))
 
+(ert-deftest typescript--number-literal-re-matches-numbers ()
+  "`typescript--number-literal-re' matches numbers."
+  (dolist (to-match '("NaN" "Infinity" "-Infinity" "-1" "1" "0.1" ".1" "-.1" "8e23"
+                      "9E-2" ".1e23" "0b1" "-0B1" "0o7" "-0O13" "0xaf" "-0XAF"))
+    (should (string-match typescript--number-literal-re to-match))
+    ;; The regular expression does not begin with ^ and end with $ so
+    ;; we need to check ourselves that the whole string is matched.
+    (should (string-equal (match-string 0 to-match) to-match))))
+
+(ert-deftest typescript--number-literal-re-does-not-match-non-numbers ()
+  "`typescript--number-literal-re' does not match non-numbers."
+  (dolist (to-match '("NaNa" "Inf" "1." "." "0xPQ" "e" "2.3e2.4"))
+    ;; For the same reason as for the positive test above, what we want is either no match
+    ;; or a match that fails to match the whole string.
+    (should-not (and (string-match typescript--number-literal-re to-match)
+                     (string-equal (match-string 0 to-match) to-match)))))
+
 (ert-deftest correctly-indents-lines-with-wide-chars ()
   "Otsuka Ai and other multi-char users should be a happy to write typescript."
 


### PR DESCRIPTION
This could potentially raise some organizational concerns with the new constant, so I'm submitting as a PR rather than just push to `master` to give folks a chance to comment.
