### PR TITLE
Class name highlighting

### DIFF
--- a/typescript-mode-tests.el
+++ b/typescript-mode-tests.el
@@ -398,6 +398,12 @@ declare function declareFunctionDefn(x3: xty3, y3: yty3): ret3;"
    "=/foo\\\\/g something // comment"
    (should (eq (get-face-at "g something") nil))))
 
+(ert-deftest font-lock/class-names ()
+  "Class names should be highlighted as types."
+  (test-with-fontified-buffer
+      "export class Foo implements Bar {}"
+    (should (eq (get-face-at "Foo") 'font-lock-type-face))
+    (should (eq (get-face-at "Bar") 'font-lock-type-face))))
 
 (defun flyspell-predicate-test (search-for)
   "This function runs a test on

--- a/typescript-mode-tests.el
+++ b/typescript-mode-tests.el
@@ -398,12 +398,28 @@ declare function declareFunctionDefn(x3: xty3, y3: yty3): ret3;"
    "=/foo\\\\/g something // comment"
    (should (eq (get-face-at "g something") nil))))
 
-(ert-deftest font-lock/class-names ()
-  "Class names should be highlighted as types."
+(ert-deftest font-lock/type-names ()
+  "Type names should be highlighted in definitions."
+  ;; Typical case.
   (test-with-fontified-buffer
-      "export class Foo implements Bar {}"
+      "export class Foo extends Bar implements Qux {}"
     (should (eq (get-face-at "Foo") 'font-lock-type-face))
-    (should (eq (get-face-at "Bar") 'font-lock-type-face))))
+    (should (eq (get-face-at "Bar") 'font-lock-type-face))
+    (should (eq (get-face-at "Qux") 'font-lock-type-face)))
+  ;; Ensure we require symbol boundaries.
+  (test-with-fontified-buffer
+      "Notclass Foo"
+    (should (not (eq (get-face-at "Foo") 'font-lock-type-face))))
+  ;; Other common ways of defining types.
+  (test-with-fontified-buffer
+      "interface Thing {}"
+    (should (eq (get-face-at "Thing") 'font-lock-type-face)))
+  (test-with-fontified-buffer
+      "enum Thing {}"
+    (should (eq (get-face-at "Thing") 'font-lock-type-face)))
+  (test-with-fontified-buffer
+      "type Thing = number;"
+    (should (eq (get-face-at "Thing") 'font-lock-type-face))))
 
 (defun flyspell-predicate-test (search-for)
   "This function runs a test on

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -1778,10 +1778,22 @@ and searches for the next token to be highlighted."
     ("\\.\\(prototype\\)\\_>"
      (1 font-lock-constant-face))
 
-    (,(rx "class" (+ space) (group (+ (or (syntax word) (syntax symbol)))))
+    (,(rx symbol-start "class" (+ space) (group (+ (or (syntax word) (syntax symbol)))))
      (1 font-lock-type-face))
 
-    (,(rx "implements" (+ space) (group (+ (or (syntax word) (syntax symbol)))))
+    (,(rx symbol-start "extends" (+ space) (group (+ (or (syntax word) (syntax symbol)))))
+     (1 font-lock-type-face))
+
+    (,(rx symbol-start "implements" (+ space) (group (+ (or (syntax word) (syntax symbol)))))
+     (1 font-lock-type-face))
+
+    (,(rx symbol-start "interface" (+ space) (group (+ (or (syntax word) (syntax symbol)))))
+     (1 font-lock-type-face))
+
+    (,(rx symbol-start "type" (+ space) (group (+ (or (syntax word) (syntax symbol)))))
+     (1 font-lock-type-face))
+
+    (,(rx symbol-start "enum" (+ space) (group (+ (or (syntax word) (syntax symbol)))))
      (1 font-lock-type-face))
 
     ;; Highlights class being declared, in parts

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -55,16 +55,10 @@
   (require 'compile)
   (require 'cc-mode)
   (require 'font-lock)
-  (require 'newcomment)
-  (require 'etags)
-  (require 'thingatpt)
-  (require 'ido)
-  (require 'json nil t))
+  (require 'newcomment))
 
 (eval-when-compile
   (require 'cl))
-
-(declare-function ido-mode "ido")
 
 ;;; Constants
 

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -55,6 +55,7 @@
   (require 'compile)
   (require 'cc-mode)
   (require 'font-lock)
+  (require 'rx)
   (require 'newcomment))
 
 (eval-when-compile
@@ -1776,6 +1777,12 @@ and searches for the next token to be highlighted."
 
     ("\\.\\(prototype\\)\\_>"
      (1 font-lock-constant-face))
+
+    (,(rx "class" (+ space) (group (+ (or (syntax word) (syntax symbol)))))
+     (1 font-lock-type-face))
+
+    (,(rx "implements" (+ space) (group (+ (or (syntax word) (syntax symbol)))))
+     (1 font-lock-type-face))
 
     ;; Highlights class being declared, in parts
     (typescript--class-decl-matcher

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2686,9 +2686,6 @@ Key bindings:
   ;; Frameworks
   (typescript--update-quick-match-re)
 
-  (setq major-mode 'typescript-mode)
-  (setq mode-name "typescript")
-
   ;; for filling, pretend we're cc-mode
   (setq c-comment-prefix-regexp "//+\\|\\**"
         c-paragraph-start "$"


### PR DESCRIPTION
Highlight class names in Typescript files, and add a test.

Before:

![screen shot 2018-05-09 at 11 12 37](https://user-images.githubusercontent.com/70800/39809569-0c78215c-537a-11e8-901f-722abbc4d884.png)

After:

![screen shot 2018-05-09 at 11 12 07](https://user-images.githubusercontent.com/70800/39809575-14d8d030-537a-11e8-954c-4a314de054fd.png)

I've also removed a few bits of unused code. These are separate commits, so you can see what's going on :)