### PR TITLE
Distinguish type arguments vs less/greater, fixes #81

### DIFF
--- a/test-files/indentation-reference-document.ts
+++ b/test-files/indentation-reference-document.ts
@@ -496,5 +496,60 @@ function blipblop(): void {
     }
 }
 
+// The following section deals with distinguishing the purpose of the symbol >
+// when it appears at the end of a line.
+// cf. https://github.com/ananthakumaran/typescript.el/issues/81
+{
+
+    var a, b, c, d, e, f, l, o, t, x, z
+    type z      = {} // Zero argument
+    type o<A>   = {} // One  argument
+    type t<A,B> = {} // Two  arguments
+
+    // greater-than operator
+    x = b >
+        c
+    // looks like a<b,c> but is greater-than operator
+    x = t < z , z >
+        f()
+    // looks almost the same but this time, it's a type
+    type x = t < z , z >
+    f()
+    // looks almost the same but this time, it's a type
+    x = a as t < z , z >
+    f()
+    // tricky, this is greater-than, because "number" is a keyword
+    a = b as number < z , z >
+        f()
+
+    // Next one is ambiguous! It could be read as:
+    // (b as t) < z, z > f()
+    // or
+    // b as (t < z , z >) \n f()
+    // It turns out that when t is not a keyword, TypeScript always chooses the
+    // latter, and complains if you attempted the former
+    a = b as t < z , z >
+    f()
+
+    l = [
+        // operator at end of line
+        a >
+            b,
+        // operator alone on line
+        a
+            >
+            b,
+        // end of 1st line is type argument, 2nd is operator
+        a as b < c , d >
+            >
+            d
+    ]
+
+    // properly-closed parameterized type, followed by operator
+    g = a as o < z > >
+        b
+
+}
+
 container.each(x => x)
 something() // No reason for this to be indented! (cf. issue #83)

--- a/test-files/indentation-reference-document.ts
+++ b/test-files/indentation-reference-document.ts
@@ -620,6 +620,9 @@ function blipblop(): void {
     type A = B<import('../file').T>
     foo
 
+    type A = import('../file').B<import('../file').C>
+    foo
+
 }
 
 container.each(x => x)

--- a/test-files/indentation-reference-document.ts
+++ b/test-files/indentation-reference-document.ts
@@ -617,6 +617,9 @@ function blipblop(): void {
     a = a ? a < a : a >
         a
 
+    type A = B<import('../file').T>
+    foo
+
 }
 
 container.each(x => x)

--- a/test-files/indentation-reference-document.ts
+++ b/test-files/indentation-reference-document.ts
@@ -549,6 +549,35 @@ function blipblop(): void {
     g = a as o < z > >
         b
 
+    // Good case
+    class Q<X> {
+        q: string = "a"
+    }
+
+    type a<X> =
+        Q<X>
+    const blah = 1
+
+    // Problem cases
+    interface Something {
+        a: string;
+        b: string;
+        c: -5;
+    }
+
+    class Fluff<X extends Something> {
+    }
+
+    // Example of = and - in a type parameter.
+    type c<X extends Something = { a: string; b: string; c: -5; more: string }>
+        = Fluff<X>
+    const moo = 1
+
+    // Example of + in a type parameter.
+    type d<X extends Something = { +readonly [P in keyof Something]: Something[P] }>
+        = Fluff<X>
+    const moo2 = 1
+
 }
 
 container.each(x => x)

--- a/test-files/indentation-reference-document.ts
+++ b/test-files/indentation-reference-document.ts
@@ -578,6 +578,40 @@ function blipblop(): void {
         = Fluff<X>
     const moo2 = 1
 
+    class Foo {
+        a : O<Z>
+        public readonly a : O<Z>
+        public b : O<Z>
+        private c : O<Z>
+        private d : O<Z>
+    }
+
+    type Foo {
+        readonly a : O<Z>
+        b : O<Z>
+        readonly b : O<Z>
+        c : { }
+        d : O<Z>
+    }
+
+    a = a ? a < a : a >
+        a
+
+    a = a ? a : a < a || a >
+        a
+
+    a = a ? a < a : a >
+        a
+    // ^ This test is the same as two above, but a bad guess could answer differently.
+
+    type Foo { }
+    a = a ? a < a : a >
+        a
+
+    class Foo { }
+    a = a ? a < a : a >
+        a
+
 }
 
 container.each(x => x)

--- a/test-files/indentation-reference-document.ts
+++ b/test-files/indentation-reference-document.ts
@@ -594,6 +594,11 @@ function blipblop(): void {
         d : O<Z>
     }
 
+    interface Foo {
+        a : O<Z>
+        b : { }
+    }
+
     a = a ? a < a : a >
         a
 

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2035,7 +2035,7 @@ This performs fontification according to `typescript--class-styles'."
   "These keywords cannot be variable or type names and start a new sentence.")
 
 (defconst typescript--type-vs-ternary-re
-  (concat "[?]\\|" (typescript--regexp-opt-symbol '("as" "class" "private" "public" "readonly")))
+  (concat "[?]\\|" (typescript--regexp-opt-symbol '("as" "class" "interface" "private" "public" "readonly")))
   "Keywords/Symbols that help tell apart colon for types vs ternary operators.")
 
 (defun typescript--search-backward-matching-angle-bracket-inner (depth)

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2124,6 +2124,8 @@ Searches specifically for any of \"=\", \"}\", and \"type\"."
                   (or
                    ;; If the previous keyword is "as", definitely a type.
                    (looking-at "\\_<as\\_>")
+                   ;; Same goes for type imports.
+                   (looking-at "\\_<import\\_>")
                    ;; A colon could be either a type symbol, or a ternary
                    ;; operator, try to guess which.
                    (and (looking-at ":")

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2031,8 +2031,10 @@ This performs fontification according to `typescript--class-styles'."
   "Regexp that matches number literals.")
 
 (defconst typescript--reserved-start-keywords-re
-  (typescript--regexp-opt-symbol '("const" "export" "function" "import" "let" "var"))
-  "These keywords cannot be variable or type names and start a new sentence.")
+  (typescript--regexp-opt-symbol '("const" "export" "function" "let" "var"))
+  "These keywords cannot be variable or type names and start a new sentence.
+Note that the \"import\" keyword can be a type import since TS2.9, so it might
+not start a sentence!")
 
 (defconst typescript--type-vs-ternary-re
   (concat "[?]\\|" (typescript--regexp-opt-symbol '("as" "class" "interface" "private" "public" "readonly")))

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2056,8 +2056,7 @@ brackets, and decreases when we cross opening brackets."
        (typescript--re-search-backward (concat "[<>]\\|" typescript--reserved-start-keywords-re) nil t)
        (case (char-after)
          (?< (typescript--search-backward-matching-angle-bracket-inner (- depth 1)))
-         (?> (typescript--search-backward-matching-angle-bracket-inner (+ depth 1)))
-         (otherwise nil)))))
+         (?> (typescript--search-backward-matching-angle-bracket-inner (+ depth 1)))))))
 
 (defun typescript--search-backward-matching-angle-bracket ()
   "Search for matching \"<\" preceding a starting \">\".


### PR DESCRIPTION
As explained in #81, the current indentation fails to discern type arguments like `t < a , b > ...` from comparison operators separated by commas like `t < a , b > ...`.

It is a somewhat hard problem to solve using only regular-expressions, yet, this patch solves all of the tricky examples listed in #81, many of which are, honestly, code that should not be written without parentheses!

So this patch:
- keeps all existing good behaviors
- patches most (all?) bad behaviors for reasonable code
- patches many(?) bad behaviors for unreasonable code

And I've kept it short and documented, so that it should not become a maintenance burden.

Cheers!