### PR TITLE
Fix unwanted indentation after non-keyword "each"

### DIFF
--- a/test-files/indentation-reference-document.ts
+++ b/test-files/indentation-reference-document.ts
@@ -495,3 +495,6 @@ function blipblop(): void {
         const q = 1;
     }
 }
+
+container.each(x => x)
+something() // No reason for this to be indented! (cf. issue #83)

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2003,8 +2003,7 @@ This performs fontification according to `typescript--class-styles'."
 
 (defconst typescript--possibly-braceless-keyword-re
   (typescript--regexp-opt-symbol
-   '("catch" "do" "else" "finally" "for" "if" "try" "while" "with"
-     "each"))
+   '("catch" "do" "else" "finally" "for" "if" "try" "while" "with"))
   "Regexp matching keywords optionally followed by an opening brace.")
 
 (defconst typescript--indent-keyword-re


### PR DESCRIPTION
Fixes #83 

AFAICT, this simple fix is enough. I'm not sure why "each" was in this list honestly, maybe it is a leftover from an old version of TypeScript where it was a keyword, but it is definitely not a keyword as of today:

https://github.com/Microsoft/TypeScript/blob/8f654f0f1ea42258275c67a7315c198f56d161f2/src/compiler/types.ts#L121-L197
