### PR TITLE
Add more jsdoc tags

### DIFF
--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -436,6 +436,7 @@ Match group 1 is MUMBLE.")
   "Matches jsdoc tags with optional type and optional param name.")
 
 ;; This was taken from js2-mode.
+;; and extended with tags in http://usejsdoc.org/
 (defconst typescript-jsdoc-typed-tag-regexp
   (concat typescript-jsdoc-before-tag-regexp
           "\\(@\\(?:"
@@ -459,11 +460,13 @@ Match group 1 is MUMBLE.")
   "Matches jsdoc tags with optional type.")
 
 ;; This was taken from js2-mode.
+;; and extended with tags in http://usejsdoc.org/
 (defconst typescript-jsdoc-arg-tag-regexp
   (concat typescript-jsdoc-before-tag-regexp
           "\\(@\\(?:"
           (regexp-opt
-           '("alias"
+           '("access"
+             "alias"
              "augments"
              "base"
              "borrows"
@@ -474,36 +477,51 @@ Match group 1 is MUMBLE.")
              "define"
              "emits"
              "exception"
+             "extends"
+             "external"
              "fires"
              "func"
              "function"
+             "host"
+             "kind"
+             "listens"
              "member"
-             "memberOf"
+             "memberof"
              "method"
+             "mixes"
              "module"
              "name"
              "namespace"
+             "requires"
              "since"
              "suppress"
              "this"
              "throws"
+             "var"
+             "variation"
              "version"))
           "\\)\\)\\s-+\\([^ \t]+\\)")
   "Matches jsdoc tags with a single argument.")
 
-;; This was taken from js2-mode.
+;; This was taken from js2-mode
+;; and extended with tags in http://usejsdoc.org/
 (defconst typescript-jsdoc-empty-tag-regexp
   (concat typescript-jsdoc-before-tag-regexp
           "\\(@\\(?:"
           (regexp-opt
-           '("addon"
+           '("abstract"
+             "addon"
+             "async"
              "author"
              "class"
+             "classdesc"
              "const"
              "constant"
              "constructor"
              "constructs"
              "copyright"
+             "default"
+             "defaultvalue"
              "deprecated"
              "desc"
              "description"
@@ -511,31 +529,44 @@ Match group 1 is MUMBLE.")
              "example"
              "exec"
              "export"
+             "exports"
+             "file"
              "fileoverview"
              "final"
              "func"
              "function"
+             "generator"
+             "global"
              "hidden"
+             "hideconstructor"
              "ignore"
-             "implicitCast"
-             "inheritDoc"
+             "implicitcast"
+             "inheritdoc"
              "inner"
+             "instance"
              "interface"
              "license"
              "method"
+             "mixin"
              "noalias"
              "noshadow"
              "notypecheck"
              "override"
+             "overview"
              "owner"
+             "package"
              "preserve"
-             "preserveTry"
+             "preservetry"
              "private"
              "protected"
              "public"
+             "readonly"
              "static"
+             "summary"
              "supported"
-             ))
+             "todo"
+             "tutorial"
+             "virtual"))
           "\\)\\)\\s-*")
   "Matches empty jsdoc tags.")
 

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -439,7 +439,7 @@ Match group 1 is MUMBLE.")
 ;; and extended with tags in http://usejsdoc.org/
 (defconst typescript-jsdoc-typed-tag-regexp
   (concat typescript-jsdoc-before-tag-regexp
-          "\\(@\\(?:"
+          "\\(@"
           (regexp-opt
            '("enum"
              "extends"
@@ -456,14 +456,14 @@ Match group 1 is MUMBLE.")
              "type"
              "yield"
              "yields"))
-          "\\)\\)\\s-*\\({[^}]+}\\)?")
+          "\\)\\s-*\\({[^}]+}\\)?")
   "Matches jsdoc tags with optional type.")
 
 ;; This was taken from js2-mode.
 ;; and extended with tags in http://usejsdoc.org/
 (defconst typescript-jsdoc-arg-tag-regexp
   (concat typescript-jsdoc-before-tag-regexp
-          "\\(@\\(?:"
+          "\\(@"
           (regexp-opt
            '("access"
              "alias"
@@ -500,14 +500,14 @@ Match group 1 is MUMBLE.")
              "var"
              "variation"
              "version"))
-          "\\)\\)\\s-+\\([^ \t]+\\)")
+          "\\)\\s-+\\([^ \t]+\\)")
   "Matches jsdoc tags with a single argument.")
 
 ;; This was taken from js2-mode
 ;; and extended with tags in http://usejsdoc.org/
 (defconst typescript-jsdoc-empty-tag-regexp
   (concat typescript-jsdoc-before-tag-regexp
-          "\\(@\\(?:"
+          "\\(@"
           (regexp-opt
            '("abstract"
              "addon"
@@ -567,7 +567,7 @@ Match group 1 is MUMBLE.")
              "todo"
              "tutorial"
              "virtual"))
-          "\\)\\)\\s-*")
+          "\\)\\s-*")
   "Matches empty jsdoc tags.")
 
 ;; Note that this regexp by itself would match tslint flags that appear inside

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -422,7 +422,13 @@ Match group 1 is MUMBLE.")
 (defconst typescript-jsdoc-param-tag-regexp
   (concat typescript-jsdoc-before-tag-regexp
           "\\(@"
-          "\\(?:param\\|arg\\(?:ument\\)?\\|prop\\(?:erty\\)?\\)"
+          (regexp-opt
+           '("arg"
+             "argument"
+             "param"
+             "prop"
+             "property"
+             "typedef"))
           "\\)"
           "\\s-*\\({[^}]+}\\)?"         ; optional type
           "\\s-*\\[?\\([[:alnum:]_$\.]+\\)?\\]?"  ; name
@@ -446,7 +452,9 @@ Match group 1 is MUMBLE.")
              "returns"
              "throw"
              "throws"
-             "type"))
+             "type"
+             "yield"
+             "yields"))
           "\\)\\)\\s-*\\({[^}]+}\\)?")
   "Matches jsdoc tags with optional type.")
 
@@ -457,10 +465,10 @@ Match group 1 is MUMBLE.")
           (regexp-opt
            '("alias"
              "augments"
-             "borrows"
-             "callback"
-             "bug"
              "base"
+             "borrows"
+             "bug"
+             "callback"
              "config"
              "default"
              "define"
@@ -472,6 +480,7 @@ Match group 1 is MUMBLE.")
              "member"
              "memberOf"
              "method"
+             "module"
              "name"
              "namespace"
              "since"


### PR DESCRIPTION
Current jsdoc tags in typescript.el do not include some tags in http://usejsdoc.org/.
This PR does
1. Update jsdoc tags to match with current js2-mode
2. Add more tags to include (almost) all tags in http://usejsdoc.org/

However, there are still some missing tags, like `@see`. `{@link}`, ... which could not be simply added by just adding their name into variables.

Resolves #86.