### PR TITLE
Fix indentation after keyword-lookalike methods.

### DIFF
--- a/test-files/indentation-reference-document.ts
+++ b/test-files/indentation-reference-document.ts
@@ -627,3 +627,28 @@ function blipblop(): void {
 
 container.each(x => x)
 something() // No reason for this to be indented! (cf. issue #83)
+
+// Method calls that look like braceless keywords should not indent!
+function test() {
+    return (
+        f.catch()
+    )
+    return (
+        f.do()
+    )
+    return (
+        f.each()
+    )
+    return (
+        f.else()
+    )
+    return (
+        f.if()
+    )
+    return (
+        f.finally()
+    )
+    return (
+        f.then()
+    )
+}

--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -2210,7 +2210,10 @@ nil."
                    (when (= (char-before) ?\)) (backward-list))
                    (skip-syntax-backward " ")
                    (skip-syntax-backward "w_")
-                   (looking-at typescript--possibly-braceless-keyword-re))
+                   (and
+                    (looking-at typescript--possibly-braceless-keyword-re)
+                    ;; If preceded by period, it's a method call.
+                    (not (= (char-before) ?.))))
                  (not (typescript--end-of-do-while-loop-p))))
       (save-excursion
         (goto-char (match-beginning 0))


### PR DESCRIPTION
Proposal to fix #85 

Problem:
The original script looks for optionally-braceless constructs, and indents when it thinks it reaches them.
Unfortunately, those same keywords can also be method names.

Solution:
Distinguish a method call by looking for a period just before the keyword.