### PR TITLE
Add autoload cookie with safe-local-var for typescript-indent-level

### DIFF
--- a/typescript-mode.el
+++ b/typescript-mode.el
@@ -605,6 +605,7 @@ Match group 1 is MUMBLE.")
   :type 'integer
   :safe 'integerp
   :group 'typescript)
+;;;###autoload(put 'typescript-indent-level 'safe-local-variable #'integerp)
 
 (defcustom typescript-expr-indent-offset 0
   "Number of additional spaces used for indentation of continued expressions.


### PR DESCRIPTION
If this is not autoloaded then it is only marked as safe from the
defcustom macro *after* the package is loaded.
This may be to late if someone opens a project with
`typescript-indent-level` as dir-local set but has not
loaded typescript-mode before.